### PR TITLE
Update to Prompt 1.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 node_js:
   - 0.8
+  - 0.10
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: node_js
 node_js:
   - "node"
+  - "0.12"
+  - "4"
+  - "5"
 
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,12 @@
 language: node_js
 node_js:
-  - 0.8
-  - 0.10
+  - "node"
+  - "0.10"
+  - "0.12"
+  - "4"
+  - "5"
 
 notifications:
   email:
     - travis@nodejitsu.com
   irc: "irc.freenode.org#nodejitsu"
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 node_js:
   - "node"
-  - "0.10"
   - "0.12"
   - "4"
   - "5"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,5 @@
 language: node_js
 node_js:
   - "node"
-  - "0.12"
-  - "4"
-  - "5"
 
-notifications:
-  email:
-    - travis@nodejitsu.com
-  irc: "irc.freenode.org#nodejitsu"
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,4 @@ notifications:
   email:
     - travis@nodejitsu.com
   irc: "irc.freenode.org#nodejitsu"
+sudo: false

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# prompt [![Build Status](https://secure.travis-ci.org/flatiron/prompt.png)](http://travis-ci.org/flatiron/prompt)
+# prompt [![Build Status](https://secure.travis-ci.org/flatiron/prompt.svg)](http://travis-ci.org/flatiron/prompt)
 
 A beautiful command-line prompt for node.js
 

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ If `ask` returns true the prompt is displayed. otherwise, the default value or e
 ``` js
   var schema = {
     properties: {
-      proxyCredentials: {
+      proxy: {
         description: 'Proxy url',
       },
       proxyCredentials: {

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ Note that, while this structure is similar to that used by prompt 0.1.x, that th
 
 ### Skipping Prompts
 
-Sometimes power users may wish to skip promts and specify all data as command line options.
+Sometimes power users may wish to skip prompts and specify all data as command line options.
 if a value is set as a property of `prompt.override` prompt will use that instead of
 prompting the user.
 
@@ -197,6 +197,45 @@ prompting the user.
   })
 
   //: node prompt-override.js --username USER --email EMAIL
+```
+
+It is also possible to skip prompts dynamically based on previous prompts.
+If an `ask` method is added, prompt will use it to determine if the prompt should be displayed.
+If `ask` returns true the prompt is displayed. otherwise, the default value or empty string are used.
+
+``` js
+  var schema = {
+    properties: {
+      proxyCredentials: {
+        description: 'Proxy url',
+      },
+      proxyCredentials: {
+        description: 'Proxy credentials',
+        ask: function() {
+          // only ask for proxy credentials if a proxy was set
+          return prompt.history('proxy').value > 0;
+        }
+      }
+    }
+  };
+
+  //
+  // Start the prompt
+  //
+  prompt.start();
+
+  //
+  // Get one or two properties from the user, depending on
+  // what the user answered for proxy
+  //
+  prompt.get(schema, function (err, result) {
+    //
+    // Log the results.
+    //
+    console.log('Command-line input received:');
+    console.log('  proxy: ' + result.proxy);
+    console.log('  credentials: ' + result.proxyCredentials);
+  });
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A beautiful command-line prompt for node.js
 * hides passwords
 
 ## Usage
-Using prompt is relatively straight forward. There are two core methods you should be aware of: `prompt.get()` and `prompt.addProperties()`. There methods take strings representing property names in addition to objects for complex property validation (and more). There are a number of [examples][0] that you should examine for detailed usage.
+Using prompt is relatively straight forward. There are two core methods you should be aware of: `prompt.get()` and `prompt.addProperties()`. Their methods take strings representing property names in addition to objects for complex property validation (and more). There are a number of [examples][0] that you should examine for detailed usage.
 
 ### Getting Basic Prompt Information
 Getting started with `prompt` is easy. Lets take a look at `examples/simple-prompt.js`:

--- a/README.md
+++ b/README.md
@@ -313,25 +313,25 @@ addition, prompt supports ANSI color codes via the
 very colorful example:
 
 ``` js
-var prompt = require("../lib/prompt");
-var colors = require("colors/safe");
-//
-// Setting these properties customizes the prompt.
-//
-prompt.message = colors.rainbow("Question!");
-prompt.delimiter = colors.green("><");
+  var prompt = require("prompt");
+  var colors = require("colors/safe");
+  //
+  // Setting these properties customizes the prompt.
+  //
+  prompt.message = colors.rainbow("Question!");
+  prompt.delimiter = colors.green("><");
 
-prompt.start();
+  prompt.start();
 
-prompt.get({
-  properties: {
-    name: {
-      description: colors.magenta("What is your name?")
+  prompt.get({
+    properties: {
+      name: {
+        description: colors.magenta("What is your name?")
+      }
     }
-  }
-}, function (err, result) {
-  console.log(colors.cyan("You said your name is: " + result.name));
-});
+  }, function (err, result) {
+    console.log(colors.cyan("You said your name is: " + result.name));
+  });
 ```
 
 If you don't want colors, you can set

--- a/README.md
+++ b/README.md
@@ -298,6 +298,88 @@ var prompt = require('prompt');
 prompt.colors = false;
 ```
 
+## Integration with streamlinejs
+
+When integrating prompt with projects using streamlinejs such as the following
+
+```
+prompt.start();
+function test_prompt(_){
+    console.log(prompt.get(loadDataValues(), _).output);
+}
+test_prompt(_);
+```
+
+This will work, however the process is then stuck with a stdin stream still open. If you setup the traditional way (with callback) such as this
+ 
+ ```
+prompt.start();
+function test_prompt(){
+    prompt.get(loadDataValues(), function(err, data){
+        console.log(data.output);
+    });
+}
+test_prompt();
+```
+
+To resolve this we have added a new method to prompt, which will stop the stdin stream
+
+```
+//
+// ### function stop ()
+// Stops input coming in from stdin
+//
+prompt.stop = function () {
+    if (prompt.stopped || !prompt.started) {
+        return;
+    }
+
+    stdin.destroy();
+    prompt.emit('stop');
+    prompt.stopped = true;
+    prompt.started = false;
+    prompt.paused = false;
+    return prompt;
+}
+```
+
+And you can find an example in the example folder (prompt-streamline.js)
+
+```
+/*
+ * prompt-streamline._js: Example of how to use prompt with streamlinejs.
+ *
+ * calling syntax: _node prompt-streamline._js
+ *
+ */
+var prompt = require('../lib/prompt');
+
+function getSampleData(){
+    return [
+        {
+            name: 'username',
+            message: 'Enter a username'
+        }
+    ];
+};
+
+//
+// Start the prompt
+//
+prompt.start();
+
+function get_username_prompt(_){
+    console.log(prompt.get(getSampleData(), _).username);
+}
+
+get_username_prompt(_);
+
+//
+// Clean the prompt
+//
+prompt.stop();
+```
+
 ## Installation
 
 ``` bash

--- a/README.md
+++ b/README.md
@@ -321,6 +321,7 @@ function test_prompt(){
 }
 test_prompt();
 ```
+This works and ends correctly.
 
 To resolve this we have added a new method to prompt, which will stop the stdin stream
 

--- a/README.md
+++ b/README.md
@@ -106,7 +106,8 @@ Here's an overview of the properties that may be used for validation and prompti
     type: 'string',                 // Specify the type of input to expect.
     pattern: /^\w+$/,                  // Regular expression that input must be valid against.
     message: 'Password must be letters', // Warning message to display if validation fails.
-    hidden: true,                        // If true, characters entered will not be output to console.
+    hidden: true,                        // If true, characters entered will either not be output to console or will be outputed using the `replace` string.
+    replace: '*',                        // It `hidden` is set it will replace each hidden character with the specified string.
     default: 'lamepassword',             // Default value to use if no value is entered.
     required: true                        // If true, value entered must be non-empty.
     before: function(value) { return 'v' + value; } // Runs before node-prompt callbacks. It modifies user's input

--- a/README.md
+++ b/README.md
@@ -344,7 +344,7 @@ prompt.stop = function () {
 }
 ```
 
-And you can find an example in the example folder (prompt-streamline.js)
+And you can find an example in the example folder `examples/prompt-streamline.js`
 
 ```
 /*

--- a/README.md
+++ b/README.md
@@ -116,6 +116,10 @@ Here's an overview of the properties that may be used for validation and prompti
 
 Alternatives to `pattern` include `format` and `conform`, as documented in [revalidator](https://github.com/flatiron/revalidator).
 
+Supported types are `string`, `boolean`, `number`, `integer`, `array`
+
+Using `type: 'boolean'` accepts case insensitive values 'true', 't', 'false', 'f'
+
 Using `type: 'array'` has some special cases.
 
 - `description` will not work in the schema if `type: 'array'` is defined.

--- a/README.md
+++ b/README.md
@@ -313,25 +313,25 @@ addition, prompt supports ANSI color codes via the
 very colorful example:
 
 ``` js
-  var prompt = require("prompt");
+var prompt = require("../lib/prompt");
+var colors = require("colors/safe");
+//
+// Setting these properties customizes the prompt.
+//
+prompt.message = colors.rainbow("Question!");
+prompt.delimiter = colors.green("><");
 
-  //
-  // Setting these properties customizes the prompt.
-  //
-  prompt.message = "Question!".rainbow;
-  prompt.delimiter = "><".green;
+prompt.start();
 
-  prompt.start();
-
-  prompt.get({
-    properties: {
-      name: {
-        description: "What is your name?".magenta
-      }
+prompt.get({
+  properties: {
+    name: {
+      description: colors.magenta("What is your name?")
     }
-  }, function (err, result) {
-    console.log("You said your name is: ".cyan + result.name.cyan);
-  });
+  }
+}, function (err, result) {
+  console.log(colors.cyan("You said your name is: " + result.name));
+});
 ```
 
 If you don't want colors, you can set
@@ -355,7 +355,7 @@ test_prompt(_);
 ```
 
 This will work, however the process is then stuck with a stdin stream still open. If you setup the traditional way (with callback) such as this
- 
+
  ```
 prompt.start();
 function test_prompt(){

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Here's an overview of the properties that may be used for validation and prompti
     pattern: /^\w+$/,                  // Regular expression that input must be valid against.
     message: 'Password must be letters', // Warning message to display if validation fails.
     hidden: true,                        // If true, characters entered will either not be output to console or will be outputed using the `replace` string.
-    replace: '*',                        // It `hidden` is set it will replace each hidden character with the specified string.
+    replace: '*',                        // If `hidden` is set it will replace each hidden character with the specified string.
     default: 'lamepassword',             // Default value to use if no value is entered.
     required: true                        // If true, value entered must be non-empty.
     before: function(value) { return 'v' + value; } // Runs before node-prompt callbacks. It modifies user's input

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ Note that, while this structure is similar to that used by prompt 0.1.x, that th
 
 ### Skipping Prompts
 
-Sometimes power users may wish to skip promts and specify all data as command line options.
+Sometimes power users may wish to skip prompts and specify all data as command line options.
 if a value is set as a property of `prompt.override` prompt will use that instead of
 prompting the user.
 

--- a/examples/color.js
+++ b/examples/color.js
@@ -1,0 +1,19 @@
+var prompt = require("../lib/prompt");
+var colors = require("colors/safe");
+//
+// Setting these properties customizes the prompt.
+//
+prompt.message = colors.rainbow("Question!");
+prompt.delimiter = colors.green("><");
+
+prompt.start();
+
+prompt.get({
+  properties: {
+    name: {
+      description: colors.magenta("What is your name?")
+    }
+  }
+}, function (err, result) {
+  console.log(colors.cyan("You said your name is: " + result.name));
+});

--- a/examples/dynamic-ask-prompt.js
+++ b/examples/dynamic-ask-prompt.js
@@ -1,0 +1,38 @@
+/*
+ * dynamic-ask-prompt.js: Dynamically decide whether to display prompt.
+ */
+
+var prompt = require('../lib/prompt');
+
+var schema = {
+  properties: {
+    proxy: {
+      description: 'Proxy url'
+    },
+    proxyCredentials: {
+      description: 'Proxy credentials',
+      ask: function() {
+        // only ask for proxy credentials if a proxy was set
+        return prompt.history('proxy').value > 0;
+      }
+    }
+  }
+};
+
+//
+// Start the prompt
+//
+prompt.start();
+
+//
+// Get one or two properties from the user, depending on
+// what the user answered for proxy
+//
+prompt.get(schema, function (err, result) {
+  //
+  // Log the results.
+  //
+  console.log('Command-line input received:');
+  console.log('  proxy: ' + result.proxy);
+  console.log('  credentials: ' + result.proxyCredentials);
+});

--- a/examples/override-validation.js
+++ b/examples/override-validation.js
@@ -47,6 +47,6 @@ prompt.get(schema, function (err, result) {
 
 // try running
 // $ node ./override-validation.js --name USER --email EMAIL
-// You will only be asked for email becasue it's invalid
+// You will only be asked for email because it's invalid
 // $ node ./override-validation.js --name h$acker --email me@example.com
-// You will only be asked for email becasue it's invalid
+// You will only be asked for name becasue it's invalid

--- a/examples/password.js
+++ b/examples/password.js
@@ -13,7 +13,7 @@ var prompt = require('../lib/prompt');
 prompt.start();
 
 //
-// Get two properties from the user: username and password
+// Get two properties from the user: username and password and password masked
 //
 prompt.get([{
     name: 'username',
@@ -24,6 +24,13 @@ prompt.get([{
     conform: function (value) {
       return true;
     }
+  }, {
+    name: 'passwordMasked',
+    hidden: true,
+    replace: '*',
+    conform: function (value) {
+      return true;
+    }
   }], function (err, result) {
   //
   // Log the results.
@@ -31,4 +38,5 @@ prompt.get([{
   console.log('Command-line input received:');
   console.log('  username: ' + result.username);
   console.log('  password: ' + result.password);
+  console.log('  passwordMasked: ' + result.passwordMasked);
 });

--- a/examples/prompt-streamline._js
+++ b/examples/prompt-streamline._js
@@ -1,0 +1,32 @@
+/*
+ * prompt-streamline._js: Example of how to use prompt with streamlinejs.
+ *
+ * calling syntax: _node prompt-streamline._js
+ *
+ */
+var prompt = require('../lib/prompt');
+
+function getSampleData(){
+    return [
+        {
+            name: 'username',
+            message: 'Enter a username'
+        }
+    ];
+};
+
+//
+// Start the prompt
+//
+prompt.start();
+
+function get_username_prompt(_){
+    console.log(prompt.get(getSampleData(), _).username);
+}
+
+get_username_prompt(_);
+
+//
+// Clean the prompt
+//
+prompt.stop();

--- a/examples/types.js
+++ b/examples/types.js
@@ -1,0 +1,20 @@
+var prompt = require('../lib/prompt');
+
+prompt.start();
+
+prompt.get([{
+    name: 'integer',
+    type: 'integer',
+    required: true
+  }, {
+    name: 'number',
+    type: 'number',
+    required: true
+  }, {
+    name: 'boolean',
+    type: 'boolean',
+    required: true
+  }], function (err, result) {
+  console.log('Input received:');
+  console.log(JSON.stringify(result, null, 2));
+});

--- a/lib/prompt.js
+++ b/lib/prompt.js
@@ -521,6 +521,9 @@ prompt.getInput = function (prop, callback) {
   //
   if(typeof defaultLine === 'undefined') {
     defaultLine = function() { return ''; };
+  } else {
+    var originalDefaultLine = defaultLine;
+    defaultLine = function() { return originalDefaultLine; };
   }
 
   //

--- a/lib/prompt.js
+++ b/lib/prompt.js
@@ -450,8 +450,8 @@ prompt.getInput = function (prop, callback) {
     delete prompt.override[propName];
   }
 
-  var type = (schema.properties && schema.properties[name] &&
-              schema.properties[name].type || '').toLowerCase().trim(),
+  var type = (schema.properties && schema.properties[propName] &&
+              schema.properties[propName].type || '').toLowerCase().trim(),
       wait = type === 'array';
 
   if (type === 'array') {
@@ -516,8 +516,8 @@ prompt.getInput = function (prop, callback) {
 
     if (line !== '') {
 
-      if (schema.properties[name]) {
-        var type = (schema.properties[name].type || '').toLowerCase().trim() || undefined;
+      if (schema.properties[propName]) {
+        var type = (schema.properties[propName].type || '').toLowerCase().trim() || undefined;
 
         //
         // Attempt to parse input as a float if the schema expects a number.

--- a/lib/prompt.js
+++ b/lib/prompt.js
@@ -532,23 +532,19 @@ prompt.getInput = function (prop, callback) {
         var type = (schema.properties[propName].type || '').toLowerCase().trim() || undefined;
 
         //
-        // Attempt to parse input as a float if the schema expects a number.
+        // If type is some sort of numeric create a Number object to pass to revalidator
         //
-        if (type == 'number') {
-          numericInput = parseFloat(line, 10);
-          if (!isNaN(numericInput)) {
-            line = numericInput;
-          }
+        if (type === 'number' || type === 'integer') {
+          line = Number(line);
         }
 
         //
         // Attempt to parse input as a boolean if the schema expects a boolean
         //
         if (type == 'boolean') {
-          if(line === "true") {
+          if(line.toLowerCase() === "true" || line.toLowerCase() === 't') {
             line = true;
-          }
-          if(line === "false") {
+          } else if(line.toLowerCase() === "false" || line.toLowerCase() === 'f') {
             line = false;
           }
         }
@@ -625,7 +621,6 @@ prompt.getInput = function (prop, callback) {
 //
 prompt._performValidation = function (name, prop, against, schema, line, callback) {
   var numericInput, valid, msg;
-
   try {
     valid = validate(against, schema);
   }

--- a/lib/prompt.js
+++ b/lib/prompt.js
@@ -11,7 +11,8 @@ var events = require('events'),
     async = utile.async,
     read = require('read'),
     validate = require('revalidator').validate,
-    winston = require('winston');
+    winston = require('winston'),
+    colors = require('colors/safe');
 
 //
 // Monkey-punch readline.Interface to work-around
@@ -436,7 +437,7 @@ prompt.getInput = function (prop, callback) {
   defaultLine = schema.default;
   name = prop.description || schema.description || propName;
   raw = prompt.colors
-    ? [name.grey, delim.grey]
+    ? [colors.grey(name), colors.grey(delim)]
     : [name, delim];
 
   if (prompt.message)

--- a/lib/prompt.js
+++ b/lib/prompt.js
@@ -632,17 +632,17 @@ prompt._performValidation = function (name, prop, against, schema, line, callbac
   }
 
   if (!valid.valid) {
-    msg = line !== -1 ? 'Invalid input for ' : 'Invalid command-line input for ';
-
-    if (prompt.colors) {
-      logger.error(msg + name.grey);
-    }
-    else {
-      logger.error(msg + name);
-    }
-
     if (prop.schema.message) {
       logger.error(prop.schema.message);
+    } else {
+      msg = line !== -1 ? 'Invalid input for ' : 'Invalid command-line input for ';
+
+      if (prompt.colors) {
+        logger.error(msg + name.grey);
+      }
+      else {
+        logger.error(msg + name);
+      }
     }
 
     prompt.emit('invalid', prop, line);

--- a/lib/prompt.js
+++ b/lib/prompt.js
@@ -6,12 +6,12 @@
  */
 
 var events = require('events'),
-    readline = require('readline'),
-    utile = require('utile'),
-    async = utile.async,
-    read = require('read'),
-    validate = require('revalidator').validate,
-    winston = require('winston');
+  readline = require('readline'),
+  utile = require('utile'),
+  async = utile.async,
+  read = require('read'),
+  validate = require('revalidator').validate,
+  winston = require('winston');
 
 //
 // Monkey-punch readline.Interface to work-around
@@ -217,7 +217,7 @@ prompt.get = function (schema, callback) {
   //
   function iterate(schema, get, done) {
     var iterator = [],
-        result = {};
+      result = {};
 
     if (typeof schema === 'string') {
       //
@@ -345,12 +345,12 @@ prompt.get = function (schema, callback) {
 //
 prompt.confirm = function (/* msg, options, callback */) {
   var args     = Array.prototype.slice.call(arguments),
-      msg      = args.shift(),
-      callback = args.pop(),
-      opts     = args.shift(),
-      vars     = !Array.isArray(msg) ? [msg] : msg,
-      RX_Y     = /^[yt]{1}/i,
-      RX_YN    = /^[yntf]{1}/i;
+    msg      = args.shift(),
+    callback = args.pop(),
+    opts     = args.shift(),
+    vars     = !Array.isArray(msg) ? [msg] : msg,
+    RX_Y     = /^[yt]{1}/i,
+    RX_YN    = /^[yntf]{1}/i;
 
   function confirm(target, next) {
     var yes = target.yes || RX_Y,
@@ -384,17 +384,17 @@ var tmp = [];
 //
 prompt.getInput = function (prop, callback) {
   var schema = prop.schema || prop,
-      propName = prop.path && prop.path.join(':') || prop,
-      storedSchema = prompt.properties[propName.toLowerCase()],
-      delim = prompt.delimiter,
-      defaultLine,
-      against,
-      hidden,
-      length,
-      valid,
-      name,
-      raw,
-      msg;
+    propName = prop.path && prop.path.join(':') || prop,
+    storedSchema = prompt.properties[propName.toLowerCase()],
+    delim = prompt.delimiter,
+    defaultLine,
+    against,
+    hidden,
+    length,
+    valid,
+    name,
+    raw,
+    msg;
 
   //
   // If there is a stored schema for `propName` in `propmpt.properties`
@@ -416,9 +416,11 @@ prompt.getInput = function (prop, callback) {
   schema = convert(schema);
   defaultLine = schema.default;
   name = prop.description || schema.description || propName;
-  raw = prompt.colors
-    ? [prompt.message, delim + name.grey, delim.grey]
-    : [prompt.message, delim + name, delim];
+  // only show the message delimiter if there is actually a message
+  var prefix = prompt.message && prompt.message.length > 0 ? prompt.message + delim : '',
+    raw = prompt.colors
+      ? [prefix, name.grey, delim.grey]
+      : [prefix, name, delim];
 
   prop = {
     schema: schema,
@@ -450,9 +452,17 @@ prompt.getInput = function (prop, callback) {
     delete prompt.override[propName];
   }
 
+  //
+  // Check if we should skip this prompt
+  //
+  if (typeof prop.schema.ask === 'function' &&
+    !prop.schema.ask()) {
+    return callback(null, prop.schema.default || '');
+  }
+
   var type = (schema.properties && schema.properties[propName] &&
-              schema.properties[propName].type || '').toLowerCase().trim(),
-      wait = type === 'array';
+      schema.properties[propName].type || '').toLowerCase().trim(),
+    wait = type === 'array';
 
   if (type === 'array') {
     length = prop.schema.maxItems;
@@ -511,8 +521,8 @@ prompt.getInput = function (prop, callback) {
     }
 
     var against = {},
-        numericInput,
-        isValid;
+      numericInput,
+      isValid;
 
     if (line !== '') {
 
@@ -721,8 +731,8 @@ prompt._remember = function (property, value) {
 //
 function convert(schema) {
   var newProps = Object.keys(validate.messages),
-      newSchema = false,
-      key;
+    newSchema = false,
+    key;
 
   newProps = newProps.concat(['description', 'dependencies']);
 

--- a/lib/prompt.js
+++ b/lib/prompt.js
@@ -502,6 +502,7 @@ prompt.getInput = function (prop, callback) {
   read({
     prompt: msg,
     silent: prop.schema && prop.schema.hidden,
+    replace: prop.schema && prop.schema.replace,
     default: defaultLine,
     input: stdin,
     output: stdout

--- a/lib/prompt.js
+++ b/lib/prompt.js
@@ -6,12 +6,12 @@
  */
 
 var events = require('events'),
-  readline = require('readline'),
-  utile = require('utile'),
-  async = utile.async,
-  read = require('read'),
-  validate = require('revalidator').validate,
-  winston = require('winston');
+    readline = require('readline'),
+    utile = require('utile'),
+    async = utile.async,
+    read = require('read'),
+    validate = require('revalidator').validate,
+    winston = require('winston');
 
 //
 // Monkey-punch readline.Interface to work-around
@@ -217,7 +217,7 @@ prompt.get = function (schema, callback) {
   //
   function iterate(schema, get, done) {
     var iterator = [],
-      result = {};
+        result = {};
 
     if (typeof schema === 'string') {
       //
@@ -345,12 +345,12 @@ prompt.get = function (schema, callback) {
 //
 prompt.confirm = function (/* msg, options, callback */) {
   var args     = Array.prototype.slice.call(arguments),
-    msg      = args.shift(),
-    callback = args.pop(),
-    opts     = args.shift(),
-    vars     = !Array.isArray(msg) ? [msg] : msg,
-    RX_Y     = /^[yt]{1}/i,
-    RX_YN    = /^[yntf]{1}/i;
+      msg      = args.shift(),
+      callback = args.pop(),
+      opts     = args.shift(),
+      vars     = !Array.isArray(msg) ? [msg] : msg,
+      RX_Y     = /^[yt]{1}/i,
+      RX_YN    = /^[yntf]{1}/i;
 
   function confirm(target, next) {
     var yes = target.yes || RX_Y,
@@ -384,17 +384,17 @@ var tmp = [];
 //
 prompt.getInput = function (prop, callback) {
   var schema = prop.schema || prop,
-    propName = prop.path && prop.path.join(':') || prop,
-    storedSchema = prompt.properties[propName.toLowerCase()],
-    delim = prompt.delimiter,
-    defaultLine,
-    against,
-    hidden,
-    length,
-    valid,
-    name,
-    raw,
-    msg;
+      propName = prop.path && prop.path.join(':') || prop,
+      storedSchema = prompt.properties[propName.toLowerCase()],
+      delim = prompt.delimiter,
+      defaultLine,
+      against,
+      hidden,
+      length,
+      valid,
+      name,
+      raw,
+      msg;
 
   //
   // If there is a stored schema for `propName` in `propmpt.properties`
@@ -461,8 +461,8 @@ prompt.getInput = function (prop, callback) {
   }
 
   var type = (schema.properties && schema.properties[propName] &&
-      schema.properties[propName].type || '').toLowerCase().trim(),
-    wait = type === 'array';
+              schema.properties[propName].type || '').toLowerCase().trim(),
+      wait = type === 'array';
 
   if (type === 'array') {
     length = prop.schema.maxItems;
@@ -521,8 +521,8 @@ prompt.getInput = function (prop, callback) {
     }
 
     var against = {},
-      numericInput,
-      isValid;
+        numericInput,
+        isValid;
 
     if (line !== '') {
 
@@ -731,8 +731,8 @@ prompt._remember = function (property, value) {
 //
 function convert(schema) {
   var newProps = Object.keys(validate.messages),
-    newSchema = false,
-    key;
+      newSchema = false,
+      key;
 
   newProps = newProps.concat(['description', 'dependencies']);
 

--- a/lib/prompt.js
+++ b/lib/prompt.js
@@ -413,8 +413,11 @@ prompt.getInput = function (prop, callback) {
   defaultLine = schema.default;
   name = prop.description || schema.description || propName;
   raw = prompt.colors
-    ? [prompt.message, delim + name.grey, delim.grey]
-    : [prompt.message, delim + name, delim];
+    ? [name.grey, delim.grey]
+    : [name, delim];
+
+  if (prompt.message)
+    raw.unshift(prompt.message, delim);
 
   prop = {
     schema: schema,

--- a/lib/prompt.js
+++ b/lib/prompt.js
@@ -41,6 +41,7 @@ var logger = prompt.logger = new winston.Logger({
 
 prompt.started    = false;
 prompt.paused     = false;
+prompt.stopped    = true;
 prompt.allowEmpty = false;
 prompt.message    = 'prompt';
 prompt.delimiter  = ': ';
@@ -94,6 +95,7 @@ prompt.start = function (options) {
 
   prompt.emit('start');
   prompt.started = true;
+  prompt.stopped = false;
   return prompt;
 };
 
@@ -102,7 +104,7 @@ prompt.start = function (options) {
 // Pauses input coming in from stdin
 //
 prompt.pause = function () {
-  if (!prompt.started || prompt.paused) {
+  if (!prompt.started || prompt.stopped || prompt.paused) {
     return;
   }
 
@@ -111,6 +113,23 @@ prompt.pause = function () {
   prompt.paused = true;
   return prompt;
 };
+
+//
+// ### function stop ()
+// Stops input coming in from stdin
+//
+prompt.stop = function () {
+    if (prompt.stopped || !prompt.started) {
+        return;
+    }
+    
+    stdin.destroy();
+    prompt.emit('stop');
+    prompt.stopped = true;
+    prompt.started = false;
+    prompt.paused = false;
+    return prompt;
+}
 
 //
 // ### function resume ()

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "test": "vows test/prompt-test.js --spec",
     "test-all": "vows --spec"
   },
+  "license": "MIT",
   "engines": {
     "node": ">= 0.6.6"
   }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "prompt",
   "description": "A beautiful command-line prompt for node.js",
-  "version": "0.2.14",
+  "version": "0.3.0",
   "author": "Nodejitsu Inc. <info@nodejitsu.com>",
   "maintainers": [
     "indexzero <charlie@nodejitsu.com>",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "prompt",
   "description": "A beautiful command-line prompt for node.js",
-  "version": "0.2.12",
+  "version": "0.2.13",
   "author": "Nodejitsu Inc. <info@nodejitsu.com>",
   "maintainers": [
     "indexzero <charlie@nodejitsu.com>",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "prompt",
-  "description": "A beautiful command-line prompt for node.js",
   "version": "1.0.0",
+  "description": "A beautiful command-line prompt for node.js",
   "author": "Nodejitsu Inc. <info@nodejitsu.com>",
   "maintainers": [
     "indexzero <charlie@nodejitsu.com>",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "read": "1.0.x",
     "revalidator": "0.1.x",
     "utile": "0.2.x",
-    "winston": "0.6.x"
+    "winston": "0.8.x"
   },
   "devDependencies": {
     "vows": "0.7.0"

--- a/package.json
+++ b/package.json
@@ -12,11 +12,12 @@
     "url": "http://github.com/flatiron/prompt.git"
   },
   "dependencies": {
+    "colors": "^1.1.2",
     "pkginfo": "0.x.x",
     "read": "1.0.x",
     "revalidator": "0.1.x",
     "utile": "0.2.x",
-    "winston": "0.8.x"
+    "winston": "2.1.x"
   },
   "devDependencies": {
     "vows": "0.7.0"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "pkginfo": "0.x.x",
     "read": "1.0.x",
     "revalidator": "0.1.x",
-    "utile": "0.2.x",
+    "utile": "0.3.x",
     "winston": "2.1.x"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "prompt",
   "description": "A beautiful command-line prompt for node.js",
-  "version": "0.2.13",
+  "version": "0.2.14",
   "author": "Nodejitsu Inc. <info@nodejitsu.com>",
   "maintainers": [
     "indexzero <charlie@nodejitsu.com>",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "prompt",
   "description": "A beautiful command-line prompt for node.js",
-  "version": "0.3.0",
+  "version": "1.0.0",
   "author": "Nodejitsu Inc. <info@nodejitsu.com>",
   "maintainers": [
     "indexzero <charlie@nodejitsu.com>",

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -104,6 +104,12 @@ helpers.schema = {
       message: 'pick a number, any number',
       default: 10
     },
+    integer: {
+      type: 'integer'
+    },
+    boolean: {
+      type: 'boolean'
+    },
     username: {
       pattern: /^[\w|\-]+$/,
       message: 'Username can only be letters, numbers, and dashes'

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -22,7 +22,7 @@ var MockReadWriteStream = helpers.MockReadWriteStream = function () {
       //console.dir(arguments);
       _emit.apply(src, arguments);
     };
-    
+
     src.on('data', function (d) {
       self.emit('data', d + '');
     })
@@ -77,7 +77,7 @@ helpers.stdin.writeSequence = function (lines) {
 // Monkey punch `util.error` to silence console output
 // and redirect to helpers.stderr for testing.
 //
-console.error = function () {
+process.stderr.write = function () {
   helpers.stderr.write.apply(helpers.stderr, arguments);
 }
 

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -6,7 +6,6 @@
  */
 
 var stream = require('stream'),
-    stream = require('stream'),
     util = require('util'),
     prompt = require('../lib/prompt');
 

--- a/test/prompt-test.js
+++ b/test/prompt-test.js
@@ -534,7 +534,34 @@ vows.describe('prompt').addBatch({
       }
     }
   }
-}).addBatch(
+}).addBatch({
+  "When using prompt": {
+    "with a type and a description property": {
+        "the get() method": {
+          topic: function () {
+            var that = this;
+            helpers.stdout.once('data', function (msg) {
+              that.msg = msg;
+            });
+
+            prompt.get({
+              name: 'test',
+              type: 'number',
+              description: 'Please input a number'
+            }, this.callback);
+            helpers.stdin.writeNextTick('42\n');
+          },
+          "should prompt to stdout and respond with the value": function (err, result) {
+            assert.isNull(err);
+            assert.include(result, 'test');
+            assert.equal(result['test'], '42');
+            assert.isTrue(this.msg.indexOf('Please input a number') !== -1);
+          }
+        },
+      }
+    }
+  })
+.addBatch(
   macros.shouldConfirm({
     messages: ['with a string message'],
     prop: 'test',

--- a/test/prompt-test.js
+++ b/test/prompt-test.js
@@ -189,7 +189,7 @@ vows.describe('prompt').addBatch({
           "should prompt with an error before completing the operation": function (err, input) {
             assert.isNull(err);
             assert.equal(input, 'some-user');
-            assert.isTrue(this.errmsg.indexOf('Invalid input') !== -1);
+            assert.isTrue(this.errmsg.indexOf('Username can only be letters, numbers, and dashes') !== -1);
             assert.isTrue(this.msg.indexOf('username') !== -1);
           }
         }

--- a/test/prompt-test.js
+++ b/test/prompt-test.js
@@ -139,6 +139,126 @@ vows.describe('prompt').addBatch({
 }).addBatch({
   "When using prompt": {
     "the getInput() method": {
+      "with an integer field": {
+        "and we provide valid input": {
+          topic: function () {
+            var that = this;
+            helpers.stdout.once('data', function (msg) {
+              that.msg = msg;
+            });
+
+            prompt.getInput(grab('integer'), this.callback);
+            helpers.stdin.writeNextTick('42\n');
+          },
+          "should prompt to stdout and respond with data": function (err, input) {
+            assert.isNull(err);
+            assert.equal(input, '42');
+            assert.isTrue(this.msg.indexOf('integer') !== -1);
+          }
+        },
+      }
+    }
+  }
+}).addBatch({
+  "When using prompt": {
+    "the getInput() method": {
+      "with an integer field": {
+        "and we don't provide an integer": {
+          topic: function () {
+            var that = this;
+            helpers.stdout.once('data', function (msg) {
+              that.msg = msg;
+            });
+
+            helpers.stderr.once('data', function (msg) {
+              that.errmsg = msg;
+            })
+
+            prompt.getInput(grab('integer'), this.callback);
+
+            prompt.once('invalid', function () {
+              prompt.once('prompt', function () {
+                process.nextTick(function () {
+                  helpers.stdin.writeNextTick('42\n');
+                })
+              })
+            });
+
+            helpers.stdin.writeNextTick('4.2\n');
+          },
+          "should prompt with an error before completing the operation": function (err, input) {
+            assert.isNull(err);
+            assert.equal(input, '42');
+            assert.isTrue(this.errmsg.indexOf('Invalid input') !== -1);
+            assert.isTrue(this.msg.indexOf('integer') !== -1);
+          }
+        }
+      }
+    }
+  }
+}).addBatch({
+  "When using prompt": {
+    "the getInput() method": {
+      "with a boolean field": {
+        "and we provide valid input": {
+          topic: function () {
+            var that = this;
+            helpers.stdout.once('data', function (msg) {
+              that.msg = msg;
+            });
+
+            prompt.getInput(grab('boolean'), this.callback);
+            helpers.stdin.writeNextTick('true\n');
+          },
+          "should prompt to stdout and respond with data": function (err, input) {
+            assert.isNull(err);
+            assert.equal(input, true);
+            assert.isTrue(this.msg.indexOf('boolean') !== -1);
+          }
+        },
+      }
+    }
+  }
+}).addBatch({
+  "When using prompt": {
+    "the getInput() method": {
+      "with a boolean field": {
+        "and we don't provide an bool": {
+          topic: function () {
+            var that = this;
+            helpers.stdout.once('data', function (msg) {
+              that.msg = msg;
+            });
+
+            helpers.stderr.once('data', function (msg) {
+              that.errmsg = msg;
+            })
+
+            prompt.getInput(grab('boolean'), this.callback);
+
+            prompt.once('invalid', function () {
+              prompt.once('prompt', function () {
+                process.nextTick(function () {
+                  helpers.stdin.writeNextTick('F\n');
+                })
+              })
+            });
+
+            helpers.stdin.writeNextTick('4.2\n');
+          },
+          "should prompt with an error before completing the operation": function (err, input) {
+            assert.isNull(err);
+            assert.equal(input, false);
+            assert.isTrue(this.errmsg.indexOf('Invalid input') !== -1);
+            assert.isTrue(this.msg.indexOf('boolean') !== -1);
+          }
+        }
+      }
+    }
+  }
+}).addBatch({
+  "When using prompt": {
+    "the getInput() method": {
       "with a complex property prompt": {
         "and a valid input": {
           topic: function () {


### PR DESCRIPTION
When using Nativescript, this fork of prompt pulls in a dependency on an older version of Winston. That older version of Winston includes a `.pem` file in its test folder. When Nativescript builds an app those dependency files get included.

The Play Store warns developers if their apps include `.pem` files that there may be a potential security flaw in their `.apk`. While no action has been taking against my app directly, Google does warn that security flaws may be ground for app removal.

Prompt 1.0.0 updates their Winston dependency so the test directory is no longer installed during an `npm install`. This pull request updates this fork of prompt to make use of those updates. By merging this pull request Nativescript should no longer pull in the old Winston, Nativescript builds should no longer contain a rogue `.pem` file, and the Play store should no longer issue warnings against Nativescript apps.
